### PR TITLE
Updated pcfproj files to point to the current tooling version

### DIFF
--- a/component-framework/TS_AngularJSFlipControl/JS_AngularJSFlipControl.pcfproj
+++ b/component-framework/TS_AngularJSFlipControl/JS_AngularJSFlipControl.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_ControlStateAPI/TS_ControlStateAPI.pcfproj
+++ b/component-framework/TS_ControlStateAPI/TS_ControlStateAPI.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_DataSetGrid/TS_DataSetGrid.pcfproj
+++ b/component-framework/TS_DataSetGrid/TS_DataSetGrid.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_DeviceApiComponent/TS_DeviceApiComponent.pcfproj
+++ b/component-framework/TS_DeviceApiComponent/TS_DeviceApiComponent.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_FormattingAPI/TS_FormattingAPI.pcfproj
+++ b/component-framework/TS_FormattingAPI/TS_FormattingAPI.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_IFrameControl/TS_IFrameControl.pcfproj
+++ b/component-framework/TS_IFrameControl/TS_IFrameControl.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_ImageUploadControl/TS_ImageUploadControl.pcfproj
+++ b/component-framework/TS_ImageUploadControl/TS_ImageUploadControl.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_LinearInputControl/TS_LinearInputControl.pcfproj
+++ b/component-framework/TS_LinearInputControl/TS_LinearInputControl.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_LocalizationAPI/TS_LocalizationAPI.pcfproj
+++ b/component-framework/TS_LocalizationAPI/TS_LocalizationAPI.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_MapControl/TS_MapControl.pcfproj
+++ b/component-framework/TS_MapControl/TS_MapControl.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_NavigationAPI/TS_NavigationAPI.pcfproj
+++ b/component-framework/TS_NavigationAPI/TS_NavigationAPI.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_ReactStandardControl/TS_ReactStandardControl.pcfproj
+++ b/component-framework/TS_ReactStandardControl/TS_ReactStandardControl.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_TableControl/TS_TableControl.pcfproj
+++ b/component-framework/TS_TableControl/TS_TableControl.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_TableGrid/TS_TableGrid.pcfproj
+++ b/component-framework/TS_TableGrid/TS_TableGrid.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/component-framework/TS_WebAPI/TS_WebAPI.pcfproj
+++ b/component-framework/TS_WebAPI/TS_WebAPI.pcfproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With the Microsoft.PowerApps.MSBuild.Pcf nuget package pointed to the 0.* version when using 1.* tooling, the build fails. This updates the samples to match the GA tooling version.