### PR TITLE
Add planned appSignalled event to AuthoringSDK samples

### DIFF
--- a/Embed/Canvas/samples/PowerAppsAuthoringSdk/README.md
+++ b/Embed/Canvas/samples/PowerAppsAuthoringSdk/README.md
@@ -9,7 +9,7 @@ This sample uses the PowerApps embedding authoring SDK to create or edit a new c
 The PowerApps Authoring SDK enables developers to:
 - Launch PowerApps Studio to allow the user to create or edit canvas apps.
 - Specify the form-factor (tablet or mobile) for a new application along with the predefined templates.
-- Subscribe to events from the Studio or Maker (like Studio Launched, App Saved, App Published) that describe the user’s interaction with the app and provides information (i.e., the application id) about the created app.
+- Subscribe to events from the Studio or Maker (like Studio Launched, App Saved, App Published, App Signalled) that describe the user’s interaction with the app and provides information (i.e., the application id) about the created app.
 - Set schema for the data which can be passed to the application during authoring/runtime.
 - Set data on the application during authoring time, this data shows up during authoring time but is not saved with application.
 - Set host method definition which allows the application to callback into the host.

--- a/Embed/Canvas/samples/PowerAppsAuthoringSdk/src/Authoring.ts
+++ b/Embed/Canvas/samples/PowerAppsAuthoringSdk/src/Authoring.ts
@@ -75,6 +75,12 @@ function subscribeToMakerSessionEvents() {
         appId = appInfo.appId;
         console.log("App is published. AppId: " + appInfo.appId);
     });
+
+    // App signalled to the host via a host definition WADL set
+    // @ts-ignore TODO: remove once upstream Authoring SDK has event merged
+    makerSession.appSignalled.subscribe((appInfo) => {
+	console.log("App signalled host. Info: " + JSON.stringify(appInfo));
+    });
 }
 
 function editApp(): void {


### PR DESCRIPTION
NOTE: the event is not yet merged into the AuthoringSDK, so I'll keep this PR as a draft until it is. The name of the event may also change, in which case I'll update the code relying on it here.