### PR TITLE
[#220] (ModelDrivenGrid) Removed CSS workaround

### DIFF
--- a/component-framework/ModelDrivenGridControl/ModelDrivenGrid/Grid.tsx
+++ b/component-framework/ModelDrivenGridControl/ModelDrivenGrid/Grid.tsx
@@ -294,7 +294,7 @@ export const Grid = React.memo((props: GridProps) => {
 
     return (
         <Stack verticalFill grow style={rootContainerStyle}>
-            <Stack.Item grow style={{ position: 'relative', backgroundColor: 'white' }}>
+            <Stack.Item grow style={{ position: 'relative', backgroundColor: 'white', zIndex: 0 }}>
                 {!itemsLoading && !isComponentLoading && items && items.length === 0 && (
                     <Stack grow horizontalAlign="center" className={'noRecords'}>
                         <Icon iconName="PageList"></Icon>

--- a/component-framework/ModelDrivenGridControl/ModelDrivenGrid/css/ModelDrivenGrid.css
+++ b/component-framework/ModelDrivenGridControl/ModelDrivenGrid/css/ModelDrivenGrid.css
@@ -6,14 +6,3 @@
     /* Large Icon */
     font-size: 300%; 
 }
-
-/* Work-around for Fluent UI StickyHeader appearing on top of the View Selector and Command Bar Flyouts */ 
-div[id^="ViewSelector"] {
-    z-index: 20;
-}
-div[id^="DialogContainer"] {
-    z-index: 20;
-}
-#__flyoutRootNode .flexbox {
-    z-index: 20;
-}


### PR DESCRIPTION
Fixes #220 by removing the CSS workaround and adding a zero z-index on the grid container.