### PR TITLE
Multiline text columns seem to work with 'RichText' date type

### DIFF
--- a/component-framework/resources/GridCustomizerControlTemplate/PAGridCustomizer/types.ts
+++ b/component-framework/resources/GridCustomizerControlTemplate/PAGridCustomizer/types.ts
@@ -198,4 +198,5 @@ export type ColumnDataType =
   | 'DateAndTime'
   | 'Image'
   | 'File'
-  | 'Persona';
+  | 'Persona'
+  | 'RichText';


### PR DESCRIPTION
Multiline of text shows the data type 'RichText'. It could be an error, since the  'Multiple' is listed in the types.ts. 
But maybe the 'RichText' is missing in the types.
Eather way, something is not quite right.