### PR TITLE
Don't clear out existing policy exclusion list

### DIFF
--- a/powershell/admin-center/Microsoft.PowerApps.Administration.PowerShell.Samples.psm1
+++ b/powershell/admin-center/Microsoft.PowerApps.Administration.PowerShell.Samples.psm1
@@ -1339,8 +1339,6 @@ function UpdatePolicyEnvironmentsForTeams
 
     if ($exceptionEnvironmentsPolicy -ne $null)
     {
-        $exceptionEnvironmentsPolicy.environments = @()
-            
         # add teams environment into ExceptEnvironments policy
         foreach ($environment in $teamEnvironments)
         {


### PR DESCRIPTION
Here is what the function does:
Takes 2 policies:
- one is OnlyEnvironments and is intended for Teams environments
- one is ExceptEnvironments and is intended for all other environments (excludes Teams)

The function takes a parameter (ExceptionEnvironmentIds) which is the list of environments that should be excluded from the second policy (in addition to the Teams environments). Here's the issue:
We wipe out the existing exclusion and start from a new list. So, if the call to get the environment from BAP around line 1360 fails (or BAP returns incomplete data or something), then that environment gets dropped from the excluded-environments list --> policy is enforced on the environment and apps/flows break.