### PR TITLE
Add examples for multi level $expand on both single and collection valued navigation properties.

### DIFF
--- a/dataverse/webapi/C#-NETx/QueryData/Program.cs
+++ b/dataverse/webapi/C#-NETx/QueryData/Program.cs
@@ -410,7 +410,7 @@ namespace QueryData
             #region Section 4 Limit and count results
 
             Console.WriteLine("\n--Section 4 started--");
-           
+
             // To limit records returned, use the $top query option.  Specifying a limit number for $top
             // returns at most that number of results per request. Extra results are ignored.
             // For more information, see:
@@ -458,7 +458,7 @@ namespace QueryData
 
             Console.WriteLine("\n--Section 5 started--");
 
-            RetrieveMultipleResponse firstPageResults = 
+            RetrieveMultipleResponse firstPageResults =
                 await service.RetrieveMultiple(
                     queryUri: "contacts?$select=fullname,jobtitle,annualincome&$filter=contains(fullname,'(sample)')&$count=true",
                     maxPageSize: 4,
@@ -488,7 +488,8 @@ namespace QueryData
             //   2) Expand using partner property (e.g.: from contact to account via the 'account_primary_contact')
             //   3) Expand using collection-valued navigation properties (e.g.: via the 'contact_customer_accounts')
             //   4) Expand using multiple navigation property types in a single request.
-            //   5) Multi-level expands
+            //   5) Multi-level expands of single-valued navigation properties.
+            //   6) Multi level $expand having both single-valued and collection-valued navigation properties.
 
             // Tip: For performance best practice, always use $select statement in an expand option.
 
@@ -581,6 +582,22 @@ namespace QueryData
 
             DisplayExpandedValuesFromTask(contosoTasks.Records);
 
+            // 6) Multi level $expand having both single-valued and collection-valued navigation properties
+
+            // The following query applies nested and multiple expands to single-valued and collection-valued navigation properties.
+            // Accounts entity is related to AccountTasks and Contacts entities. Contacts entity is further expanded on OwningUser navigation property.
+
+            RetrieveMultipleResponse accounts =
+                await service.RetrieveMultiple(queryUri: $"accounts?" +
+                $"$select=name,accountid&" +
+                $"$filter= accountid eq {accountContosoRef.Id} &" +
+                $"$expand=Account_Tasks($select=subject,description),contact_customer_accounts($select=lastname;" +
+                $"$expand=owninguser($select=firstname,systemuserid))",
+                includeAnnotations: true);
+
+            Console.WriteLine("\nExpanded values from Accounts:");
+            DisplayExpandedValuesFromAccount(accounts.Records);
+
             #endregion Section 6 Expanding results
 
             #region Section 7 Aggregate results
@@ -609,7 +626,7 @@ namespace QueryData
             #region Section 8 FetchXML queries
 
             Console.WriteLine("\n--Section 8 started--");
-           
+
             // Use FetchXML to query for all contacts whose fullname contains '(sample)'.
             // Note: XML string must be URI encoded. For more information, see:
             // https://docs.microsoft.com/power-apps/developer/data-platform/webapi/use-fetchxml-web-api
@@ -702,7 +719,7 @@ namespace QueryData
             // Loop through subsequent requests while more records match criteria
             while (cookiePagedContacts.MoreRecords) {
 
-                page++;
+                    page++;
 
                 fetchXmlQueryDoc.Root.Attribute("page").Value = page.ToString();
 
@@ -773,7 +790,7 @@ namespace QueryData
             // https://docs.microsoft.com/power-apps/developer/data-platform/saved-queries
             Console.WriteLine("\n-- User Query -- ");
 
-            
+
             var userQuery = new JObject()
             {
                 { "name","My User Query"},
@@ -953,6 +970,42 @@ namespace QueryData
                     $"{task["regardingobjectid_contact_task"]["parentcustomerid_account"]["name"],col3}|" +
                     $"{task["regardingobjectid_contact_task"]["parentcustomerid_account"]["createdby"]["fullname"],col4}");
 
+            }
+        }
+
+        /// <summary>
+        /// Helper method to display expanded values from account records
+        /// </summary>
+        /// <param name="collection">The collection of account records.</param>
+        private static void DisplayExpandedValuesFromAccount(JToken collection)
+        {
+
+            //Display column widths for task Lookup Values Table
+            const int col1 = -30;
+            const int col2 = -30;
+
+            //rows
+            foreach (JObject account in collection)
+            {
+                Console.WriteLine($"Account: {account["name"]}");
+
+                Console.WriteLine($"\t|{"Account Task",col1}|");
+                Console.WriteLine($"\t|{new string('-', col1 * -1),col1}|");
+
+                foreach (JObject accountTasks in account["Account_Tasks"])
+                {
+                    Console.WriteLine($"\t|{accountTasks["subject"],col1}|");
+                }
+
+                Console.WriteLine($"\n\t|{"Contact",col1}|" + $"{"System User",col2}|");
+                Console.WriteLine($"\t|{new string('-', col1 * -1),col1}|" +
+                    $"{new string('-', col2 * -1),col2}|");
+
+                foreach (JObject contacts in account["contact_customer_accounts"])
+                {
+                    Console.WriteLine($"\t|{contacts["lastname"],col1}|" +
+                        $"{contacts["owninguser"]["firstname"],col2}|");
+                }
             }
         }
     }

--- a/dataverse/webapi/C#-NETx/QueryData/Program.cs
+++ b/dataverse/webapi/C#-NETx/QueryData/Program.cs
@@ -458,7 +458,7 @@ namespace QueryData
 
             Console.WriteLine("\n--Section 5 started--");
 
-            RetrieveMultipleResponse firstPageResults =
+            RetrieveMultipleResponse firstPageResults = 
                 await service.RetrieveMultiple(
                     queryUri: "contacts?$select=fullname,jobtitle,annualincome&$filter=contains(fullname,'(sample)')&$count=true",
                     maxPageSize: 4,
@@ -584,7 +584,7 @@ namespace QueryData
 
             // 6) Multi level $expand having both single-valued and collection-valued navigation properties
 
-            // The following query applies nested and multiple expands to single-valued and collection-valued navigation properties.
+            // The following query applies nested expands to single-valued and collection-valued navigation properties.
             // Accounts entity is related to AccountTasks and Contacts entities. Contacts entity is further expanded on OwningUser navigation property.
 
             RetrieveMultipleResponse accounts =
@@ -626,7 +626,7 @@ namespace QueryData
             #region Section 8 FetchXML queries
 
             Console.WriteLine("\n--Section 8 started--");
-
+            
             // Use FetchXML to query for all contacts whose fullname contains '(sample)'.
             // Note: XML string must be URI encoded. For more information, see:
             // https://docs.microsoft.com/power-apps/developer/data-platform/webapi/use-fetchxml-web-api
@@ -719,7 +719,7 @@ namespace QueryData
             // Loop through subsequent requests while more records match criteria
             while (cookiePagedContacts.MoreRecords) {
 
-                    page++;
+                page++;
 
                 fetchXmlQueryDoc.Root.Attribute("page").Value = page.ToString();
 


### PR DESCRIPTION
**Changes are only done for Section-6.**
Query-6:
_accounts?$select=name,accountid&$filter= accountid eq << accountContosoId >> &$expand=Account_Tasks($select=subject,description),contact_customer_accounts($select=lastname;$expand=owninguser($select=firstname,systemuserid))_

Results shown:
![image](https://user-images.githubusercontent.com/128368791/227408381-f6ce8f73-80b6-4cbc-bb32-9d7451145252.png)
