### PR TITLE
Copy App.config to output folder

### DIFF
--- a/dataverse/Xrm Tooling/AppWithLoginControl/Desktop-app-using-login-control.csproj
+++ b/dataverse/Xrm Tooling/AppWithLoginControl/Desktop-app-using-login-control.csproj
@@ -216,7 +216,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/dataverse/Xrm Tooling/QuickStartCS/QuickStartCS/QuickStartCS.csproj
+++ b/dataverse/Xrm Tooling/QuickStartCS/QuickStartCS/QuickStartCS.csproj
@@ -181,6 +181,7 @@
   <ItemGroup>
     <None Include="..\..\..\App.config">
       <Link>App.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
   </ItemGroup>

--- a/dataverse/Xrm Tooling/TPLCrmServiceClient/TPLCrmServiceClient.csproj
+++ b/dataverse/Xrm Tooling/TPLCrmServiceClient/TPLCrmServiceClient.csproj
@@ -173,6 +173,7 @@
   <ItemGroup>
     <None Include="..\..\App.config">
       <Link>App.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
     <None Include="README.md" />


### PR DESCRIPTION
The App.config file was not being copied to the output folder when building.