### PR TITLE
Add validation in UpdateCMKEnterprisePolicy script

### DIFF
--- a/powershell/enterprisePolicies/Cmk/CreateCMKEnterprisePolicy.ps1
+++ b/powershell/enterprisePolicies/Cmk/CreateCMKEnterprisePolicy.ps1
@@ -57,6 +57,11 @@ function CreateCMKEnterprisePolicy
 
     Write-Host "Logged In..." -ForegroundColor Green
 
+    if ($keyVersion -eq "N/A")
+    {
+        $keyVersion = $null
+    }
+	
     $body = GenerateEnterprisePolicyBody -policyType "cmk" -policyLocation $enterprisePolicyLocation -policyName $enterprisePolicyName -keyVaultId $keyVaultId -keyName $keyName -keyVersion $keyVersion
 
     $result = PutEnterprisePolicy $resourceGroup $body

--- a/powershell/enterprisePolicies/Cmk/UpdateCMKEnterprisePolicy.ps1
+++ b/powershell/enterprisePolicies/Cmk/UpdateCMKEnterprisePolicy.ps1
@@ -59,31 +59,60 @@ function UpdateCMKEnterprisePolicy
 
     $policyArmId = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup/providers/Microsoft.PowerPlatform/enterprisePolicies/$enterprisePolicyName"
     $policy = GetEnterprisePolicy $policyArmId
+    if ($policy -eq $null)
+    {
+         Write-Host "CMK Enterprise Policy not found for $policyArmId" -ForegroundColor Red 
+         return
+    }
+
+    if ($policy.Kind -ne "Encryption")
+    {
+        $kindString = $policy.Kind | ConvertTo-Json
+        Write-Host "Enterprise found for $policyArmId is not CMK Enterprise Policy. Policy is of type $kindString " -ForegroundColor Red 
+        return
+    }
+
+    if ($policy.Identity -eq $null -or $policy.Identity.Type -ne "SystemAssigned")
+    {
+        $identityString = $policy.Identity | ConvertTo-Json -Depth 7
+        Write-Host "Enterprise found for $policyArmId is not having valid Identity property $identityString" -ForegroundColor Red 
+        return
+    }
+    
+    $keyVaultIdUpdated =  $policy.properties.encryption.keyVault.id
+    $keyNameUpdated = $policy.properties.encryption.keyVault.key.name
+    $keyVersionUpdated = $policy.properties.encryption.keyVault.key.version
     if ($keyVaultId -ne "N/A")
     {
         Write-Host "Updating KeyVaultId as $keyVaultId" -ForegroundColor Green
-        $policy.properties.encryption.keyVault.id = $keyVaultId
+        $keyVaultIdUpdated = $keyVaultId
     }
     if ($keyName -ne "N/A")
     {
         Write-Host "Updating keyName as $keyName" -ForegroundColor Green
-        $policy.properties.encryption.keyVault.key.name = $keyName
+        $keyNameUpdated = $keyName
     }
     if ($keyVersion -ne "N/A")
     {
         Write-Host "Updating keyVersion as $keyVersion" -ForegroundColor Green
-        $policy.properties.encryption.keyVault.key.version = $keyVersion
+        $keyVersionUpdated = $keyVersion
     }
 
-    $updatedPolicy = UpdateEnterprisePolicy $policy
-    if ($updatedPolicy.ResourceId -eq $null)
+    $body = GenerateEnterprisePolicyBody -policyType "cmk" -policyLocation $policy.Location -policyName $policy.Name -keyVaultId $keyVaultIdUpdated -keyName $keyNameUpdated -keyVersion $keyVersionUpdated
+    $body.resources.identity.Add("principalId", $policy.Identity.PrincipalId)
+    $body.resources.identity.Add("tenantId", $policy.Identity.TenantId)
+
+    $result = PutEnterprisePolicy $resourceGroup $body
+    if ($result -eq $false)
     {
-         Write-Host "Policy not updated"
-         return
+       return
     }
-    $policyString = $updatedPolicy | ConvertTo-Json -Depth 7
-    Write-Host "Policy updated"
-    Write-Host $policyString
 
+    Write-Host "CMK Enterprise policy updated" -ForegroundColor Green 
+
+    $policy = GetEnterprisePolicy $policyArmId
+    $policyString = $policy | ConvertTo-Json -Depth 7
+    Write-Host "The updated policy"
+    Write-Host $policyString
 }
 UpdateCMKEnterprisePolicy

--- a/powershell/enterprisePolicies/Common/EnterprisePolicyOperations.ps1
+++ b/powershell/enterprisePolicies/Common/EnterprisePolicyOperations.ps1
@@ -37,7 +37,7 @@ function PutEnterprisePolicy($resourceGroup, $body)
         return $true
     }
     $policyString = $policy | ConvertTo-Json
-    Write-Host "Error creating Enterprise policy $policyString `n" -ForegroundColor Red
+    Write-Host "Error creating/updating Enterprise policy $policyString `n" -ForegroundColor Red
     return $false
 
 


### PR DESCRIPTION
The code in this PR fixes the UpdateCMKEP script:

- the script was throwing  error for "Identity not present" when updating CMK enterprise policy. The code change now gets all the values from GET enterprise policy and adds them to the update request
-  additionally, CMK enterprise policy validation are added on GET enterprise policy. This ensures that input CMK enterprise policy is a valid CMK enterprise policy

