### PR TITLE
Address issue #477

### DIFF
--- a/component-framework/DataSetGrid/.eslintrc.json
+++ b/component-framework/DataSetGrid/.eslintrc.json
@@ -15,6 +15,7 @@
   "plugins": ["@microsoft/power-apps", "@typescript-eslint"],
   "rules": {
     "no-unused-vars": "off",
-    "no-undef": "off"
+    "no-undef": "off",
+    "@typescript-eslint/no-empty-interface": "off"
   }
 }


### PR DESCRIPTION
#477

Adding rule "@typescript-eslint/no-empty-interface": "off" to DataSetGrid