### PR TITLE
FIX Support for PowerShell pre 6.2 (Join-String)

### DIFF
--- a/powershell/connectors/HTTPWithMicrosoftEntraId/ManagePermissionGrant.ps1
+++ b/powershell/connectors/HTTPWithMicrosoftEntraId/ManagePermissionGrant.ps1
@@ -224,7 +224,7 @@ $selectedSPId = $selectedSP.Id
 $scopes = $selectedSP.Oauth2PermissionScopes | Sort-Object Value | Select-Object Type, Value, UserConsentDisplayName, UserConsentDescription
 $selectedScopes = $scopes | Out-GridView -Title "Choose Scopes" -OutputMode Multiple
 
-$joinedScopes = $selectedScopes | Join-String -Property {$_.Value} -Separator ' '
+$joinedScopes = $($selectedScopes | Select-Object -ExpandProperty Value) -join ' '
 Write-Host "The following user scopes have been selected: $joinedScopes"
 
 If (!$selectedScopes)


### PR DESCRIPTION
Fixes #511 

The original script seems to only support PowerShell 6.2 and up as Join-String was introduced in 6.2.
This should work on at least 5.1.