### PR TITLE
Fix issue in AngularJSFlipControl passing a number value to a boolean input/output which caused rendering errors.

### DIFF
--- a/component-framework/AngularJSFlipControl/AngularJSFlipControl/index.ts
+++ b/component-framework/AngularJSFlipControl/AngularJSFlipControl/index.ts
@@ -1,13 +1,13 @@
 /*
-	This file is part of the Microsoft PowerApps code samples. 
-	Copyright (C) Microsoft Corporation.  All rights reserved. 
-	This source code is intended only as a supplement to Microsoft Development Tools and/or  
-	on-line documentation.  See these other materials for detailed information regarding  
-	Microsoft code samples. 
+	This file is part of the Microsoft PowerApps code samples.
+	Copyright (C) Microsoft Corporation.  All rights reserved.
+	This source code is intended only as a supplement to Microsoft Development Tools and/or
+	on-line documentation.  See these other materials for detailed information regarding
+	Microsoft code samples.
 
-	THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER  
-	EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF  
-	MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE. 
+	THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER
+	EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF
+	MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 /**
@@ -58,7 +58,12 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 	 * @param state A piece of data that persists in one session for a single user. Can be set at any point in a controls life cycle by calling 'setControlState' in the Mode interface.
 	 * @param container If a control is marked control-type='standard', it will receive an empty div element within which it can render its content.
 	 */
-	public init(context: ComponentFramework.Context<IInputs>, notifyOutputChanged: () => void, state: ComponentFramework.Dictionary, container: HTMLDivElement): void {
+	public init(
+		context: ComponentFramework.Context<IInputs>,
+		notifyOutputChanged: () => void,
+		state: ComponentFramework.Dictionary,
+		container: HTMLDivElement
+	): void {
 		// We need a random integer from 1-100, so that for a form of multiple fields bind to same attribute, we could differentiate
 		const randomInt: number = Math.floor(Math.floor(100) * Math.random());
 
@@ -81,40 +86,48 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 
 		// Below sample html are from Angular-UI single toggle sample code
 		// https://angular-ui.github.io/bootstrap/
-		appDiv.innerHTML = "<pre>{{labelModel}}</pre><button type='button' class='btn btn-primary' ng-model='flipButtonModel' uib-btn-checkbox btn-checkbox-true='1' btn-checkbox-false='0'>Flip</button>";
+		appDiv.innerHTML =
+			"<pre>{{labelModel}}</pre><button type='button' class='btn btn-primary' ng-model='flipButtonModel' uib-btn-checkbox btn-checkbox-true='1' btn-checkbox-false='0'>Flip</button>";
 
 		// Container appends the HTML structure
 		container.appendChild(appDiv);
 
 		// Angular code. Angular module/controller initialization.
-		angular.module(this._controllerId, [require("angular-animate"), require("angular-sanitize"), require("angular-ui-bootstrap")]);
+		angular.module(this._controllerId, [
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			require("angular-animate"),
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			require("angular-sanitize"),
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			require("angular-ui-bootstrap"),
+		]);
 		angular.module(this._controllerId).controller(this._appId, ($scope) => {
 			// Intialize 'labelModel'. Assign initial option text to the Angular $scope labelModel. It will be revealed in '<pre>{{labelModel}}</pre>'
 			$scope.labelModel = this._currentValue ? this._optionTrueLabel : this._optionFalseLabel;
 
 			// Intialize 'flipButtonModel'. Assign bind attribute value to Angular $scope flipButtonModel. The Flip button also bind to this 'flipButtonModel', so when we click, it will flip
-			$scope.flipButtonModel = this._currentValue ? 1 : 0;
+			$scope.flipButtonModel = this._currentValue ? 0 : 1;
 
 			// Watch the click of the flip button
 			$scope.$watchCollection("flipButtonModel", () => {
 				// Update the label text when Flip Button clicks
 				if ($scope.flipButtonModel) {
-					$scope.labelModel = this._optionTrueLabel;
-				}
-				else {
 					$scope.labelModel = this._optionFalseLabel;
+				} else {
+					$scope.labelModel = this._optionTrueLabel;
 				}
 
 				// Call updateOutputIfNeeded and inform PCF framework that bind attribute value need update
-				this.updateOutputIfNeeded($scope.flipButtonModel);
-
+				this.updateOutputIfNeeded(!$scope.flipButtonModel);
 			});
 		});
 
 		// Angular code. Create an App based on the new appDivId
 		angular.element(document).ready(() => {
 			const divId = document.getElementById(this._appDivId);
-			divId && angular.bootstrap(divId, [this._controllerId]);
+			if (divId) {
+				angular.bootstrap(divId, [this._controllerId]);
+			}
 		});
 	}
 
@@ -124,8 +137,12 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 	 * @param passInString input string as suffix
 	 * @param randomInt random integer
 	 * @returns a string of uniqueId includes attribute logicalname + passIn specialized string + random Integer
-	*/
-	private createUniqueId(context: ComponentFramework.Context<IInputs>, passInString: string, randomInt: number): string {
+	 */
+	private createUniqueId(
+		context: ComponentFramework.Context<IInputs>,
+		passInString: string,
+		randomInt: number
+	): string {
 		return `${context.parameters?.flipModel.attributes?.LogicalName}-${passInString}${randomInt}`;
 	}
 
@@ -138,10 +155,9 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 		const optionsMetadata = context.parameters.flipModel.attributes?.Options;
 		optionsMetadata?.forEach((option: ComponentFramework.PropertyHelper.OptionMetadata) => {
 			if (option.Value) {
-				this._optionTrueLabel = option.Label;
-			}
-			else {
 				this._optionFalseLabel = option.Label;
+			} else {
+				this._optionTrueLabel = option.Label;
 			}
 		});
 	}
@@ -157,9 +173,10 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 			// Angular Code. Update the 'flipButtonModel' value
 			const $scope = angular.element(document.getElementById(this._appDivId) as HTMLElement).scope();
 
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			$scope.$apply(($scope: any) => {
 				// 'flipButtonModel' value is either 1 or 0
-				$scope.flipButtonModel = newValue ? 1 : 0;
+				$scope.flipButtonModel = newValue ? 0 : 1;
 			});
 		}
 	}
@@ -184,9 +201,8 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 		this.updateFlipButtonModelIfNeeded(context.parameters.flipModel.raw);
 	}
 
-
-	/** 
-	 * It is called by the framework prior to a control receiving new data. 
+	/**
+	 * It is called by the framework prior to a control receiving new data.
 	 * @returns an object based on nomenclature defined in manifest, expecting object[s] for property marked as "bound" or "output"
 	 */
 	public getOutputs(): IOutputs {
@@ -194,7 +210,7 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 		return { flipModel: returnValue };
 	}
 
-	/** 
+	/**
 	 * Called when the control is to be removed from the DOM tree. Controls should use this call for cleanup.
 	 * i.e. cancelling any pending remote calls, removing listeners, etc.
 	 */


### PR DESCRIPTION
Fix for #251 and some linting fixes along the way.

If the issue in #251 was hit earlier, then the application cache needs to be cleaned as the old invalid number value will keep being used until cleared out.

![{99D2B834-7ED6-401E-A926-5B50D02C815C}](https://github.com/user-attachments/assets/3feb910e-6f64-4983-be24-dd15a770ae28)
