### PR TITLE
Fix styling not being applied to AngularJSFlipControl

### DIFF
--- a/component-framework/AngularJSFlipControl/AngularJSFlipControl/css/AngularJSFlipControl.css
+++ b/component-framework/AngularJSFlipControl/AngularJSFlipControl/css/AngularJSFlipControl.css
@@ -24,7 +24,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */ /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 
 /* Below CSS are based on Boostrap v3.3.7 */
-.SampleNamespace\.JSAngularJSFlipControl pre {
+.SampleNamespace\.AngularJSFlipControl pre {
 	display: block;
 	padding: 9.5px;
 	margin: 0 0 10px;
@@ -37,41 +37,41 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 	border: 1px solid #ccc;
 	border-radius: 4px;
 }
-.SampleNamespace\.JSAngularJSFlipControl pre {
+.SampleNamespace\.AngularJSFlipControl pre {
 	font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
-.SampleNamespace\.JSAngularJSFlipControl pre {
+.SampleNamespace\.AngularJSFlipControl pre {
 	overflow: auto;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary {
+.SampleNamespace\.AngularJSFlipControl .btn-primary {
 	color: #fff;
 	background-color: #337ab7;
 	border-color: #2e6da4;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary:focus {
+.SampleNamespace\.AngularJSFlipControl .btn-primary.focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary:focus {
 	color: #fff;
 	background-color: #286090;
 	border-color: #122b40;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary:hover {
+.SampleNamespace\.AngularJSFlipControl .btn-primary:hover {
 	color: #fff;
 	background-color: #286090;
 	border-color: #204d74;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.active,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary:active,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.active,
+.SampleNamespace\.AngularJSFlipControl .btn-primary:active,
 .open > .dropdown-toggle.btn-primary {
 	color: #fff;
 	background-color: #286090;
 	border-color: #204d74;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.active.focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.active:focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.active:hover,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary:active.focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary:active:focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary:active:hover,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.active.focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.active:focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.active:hover,
+.SampleNamespace\.AngularJSFlipControl .btn-primary:active.focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary:active:focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary:active:hover,
 .open > .dropdown-toggle.btn-primary.focus,
 .open > .dropdown-toggle.btn-primary:focus,
 .open > .dropdown-toggle.btn-primary:hover {
@@ -79,28 +79,28 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 	background-color: #204d74;
 	border-color: #122b40;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.active,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary:active,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.active,
+.SampleNamespace\.AngularJSFlipControl .btn-primary:active,
 .open > .dropdown-toggle.btn-primary {
 	background-image: none;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.disabled.focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.disabled:focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.disabled:hover,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary[disabled].focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary[disabled]:focus,
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary[disabled]:hover,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.disabled.focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.disabled:focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary.disabled:hover,
+.SampleNamespace\.AngularJSFlipControl .btn-primary[disabled].focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary[disabled]:focus,
+.SampleNamespace\.AngularJSFlipControl .btn-primary[disabled]:hover,
 fieldset[disabled].btn-primary.focus,
 fieldset[disabled].btn-primary:focus,
 fieldset[disabled].btn-primary:hover {
 	background-color: #337ab7;
 	border-color: #2e6da4;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn-primary.badge {
+.SampleNamespace\.AngularJSFlipControl .btn-primary.badge {
 	color: #337ab7;
 	background-color: #fff;
 }
-.SampleNamespace\.JSAngularJSFlipControl .btn {
+.SampleNamespace\.AngularJSFlipControl .btn {
 	display: inline-block;
 	padding: 6px 12px;
 	margin-bottom: 0;

--- a/component-framework/AngularJSFlipControl/AngularJSFlipControl/index.ts
+++ b/component-framework/AngularJSFlipControl/AngularJSFlipControl/index.ts
@@ -68,7 +68,7 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 		const randomInt: number = Math.floor(Math.floor(100) * Math.random());
 
 		this._appDivId = this.createUniqueId(context, "angularflip_controlid", randomInt);
-		this._appId = this.createUniqueId(context, "JSAngularJSFlipControl", randomInt);
+		this._appId = this.createUniqueId(context, "AngularJSFlipControl", randomInt);
 		this._controllerId = this.createUniqueId(context, "powerApps.angularui.demo", randomInt);
 		this._notifyOutputChanged = notifyOutputChanged;
 
@@ -93,14 +93,7 @@ export class AngularJSFlipControl implements ComponentFramework.StandardControl<
 		container.appendChild(appDiv);
 
 		// Angular code. Angular module/controller initialization.
-		angular.module(this._controllerId, [
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
-			require("angular-animate"),
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
-			require("angular-sanitize"),
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
-			require("angular-ui-bootstrap"),
-		]);
+		angular.module(this._controllerId, [ngAnimate, ngSanitize, uiBootstrap]);
 		angular.module(this._controllerId).controller(this._appId, ($scope) => {
 			// Intialize 'labelModel'. Assign initial option text to the Angular $scope labelModel. It will be revealed in '<pre>{{labelModel}}</pre>'
 			$scope.labelModel = this._currentValue ? this._optionTrueLabel : this._optionFalseLabel;


### PR DESCRIPTION
Namespace name in CSS wasn't matching with ids in DOM resulting in elements not being styled.

Before change:
![{E6A53E85-9EF5-45F8-9AE6-8C5BA5D57018}](https://github.com/user-attachments/assets/a4b59482-9557-48fc-a5cf-516fd9433905)

After change:
![{95FEBE82-6047-4FCF-A643-DF60D6FDDD24}](https://github.com/user-attachments/assets/0c84fa93-17ab-4d8a-8926-e77db878b767)

