### PR TITLE
Update fluent v8 platform library version for component-framework samples

### DIFF
--- a/component-framework/ChoicesPickerReactControl/ChoicesPickerReact/ControlManifest.Input.xml
+++ b/component-framework/ChoicesPickerReactControl/ChoicesPickerReact/ControlManifest.Input.xml
@@ -36,7 +36,7 @@
     <resources>
       <code path="index.ts" order="1"/>
       <platform-library name="React" version="16.14.0" />
-      <platform-library name="Fluent" version="8.29.0" />
+      <platform-library name="Fluent" version="8.121.1" />
       <!-- UNCOMMENT TO ADD MORE RESOURCES
       <css path="css/ChoicesPickerReact.css" order="1" />
       <resx path="strings/ChoicesPickerReact.1033.resx" version="1.0.0" />

--- a/component-framework/ChoicesPickerReactControl/package.json
+++ b/component-framework/ChoicesPickerReactControl/package.json
@@ -13,7 +13,7 @@
 		"refreshTypes": "pcf-scripts refreshTypes"
 	},
 	"dependencies": {
-		"@fluentui/react": "8.29.0",
+		"@fluentui/react": "8.121.1",
 		"react": "^16.14.0",
 		"react-dom": "^16.14.0"
 	},

--- a/component-framework/FacepileReactControl/FacepileReact/ControlManifest.Input.xml
+++ b/component-framework/FacepileReactControl/FacepileReact/ControlManifest.Input.xml
@@ -5,7 +5,7 @@
     <resources>
       <code path="index.ts" order="1"/>
       <platform-library name="React" version="16.14.0" />
-      <platform-library name="Fluent" version="8.29.0" />
+      <platform-library name="Fluent" version="8.121.1" />
       <css path="css/FacepileReactControl.css" order="2" />
       <resx path="strings/FacepileReactControl.1033.resx" version="1.0.0" />
     </resources>

--- a/component-framework/FacepileReactControl/FacepileReact/components/Facepile.tsx
+++ b/component-framework/FacepileReactControl/FacepileReact/components/Facepile.tsx
@@ -32,7 +32,8 @@ export class FacepileBasicExample extends React.Component<IFacepileBasicExampleP
 		super(props);
 
 		this.state = {
-			numberOfFaces: props.numberOfFaces ?? 3,
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			numberOfFaces: props.numberOfFaces || 3,
 			imagesFadeIn: true,
 			personaSize: PersonaSize.size32,
 		};

--- a/component-framework/FacepileReactControl/FacepileReact/index.ts
+++ b/component-framework/FacepileReactControl/FacepileReact/index.ts
@@ -31,7 +31,8 @@ export class FacepileReact implements ComponentFramework.ReactControl<IInputs, I
 		state: ComponentFramework.Dictionary
 	): void {
 		this.notifyOutputChanged = notifyOutputChanged;
-		this.props.numberOfFaces = context.parameters.numberOfFaces.raw ?? DEFAULT_NUMBER_OF_FACES;
+		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+		this.props.numberOfFaces = context.parameters.numberOfFaces.raw || DEFAULT_NUMBER_OF_FACES;
 	}
 
 	/**
@@ -40,7 +41,8 @@ export class FacepileReact implements ComponentFramework.ReactControl<IInputs, I
 	 */
 	public updateView(context: ComponentFramework.Context<IInputs>): React.ReactElement {
 		if (context.updatedProperties.includes("numberOfFaces")) {
-			this.props.numberOfFaces = context.parameters.numberOfFaces.raw ?? DEFAULT_NUMBER_OF_FACES;
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			this.props.numberOfFaces = context.parameters.numberOfFaces.raw || DEFAULT_NUMBER_OF_FACES;
 		}
 		return React.createElement(FacepileBasicExample, this.props);
 	}

--- a/component-framework/FacepileReactControl/package.json
+++ b/component-framework/FacepileReactControl/package.json
@@ -13,7 +13,7 @@
 		"refreshTypes": "pcf-scripts refreshTypes"
 	},
 	"dependencies": {
-		"@fluentui/react": "8.29.0",
+		"@fluentui/react": "8.121.1",
 		"react": "^16.14.0",
 		"react-dom": "^16.14.0"
 	},

--- a/component-framework/LinearInputControl/LinearInputControl/index.ts
+++ b/component-framework/LinearInputControl/LinearInputControl/index.ts
@@ -80,11 +80,11 @@ export class LinearInputControl implements ComponentFramework.StandardControl<II
 		this._value = context.parameters.controlValue.raw!;
 		this.inputElement.setAttribute(
 			"value",
-			context.parameters.controlValue.formatted ? context.parameters.controlValue.formatted : "0"
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			context.parameters.controlValue.formatted || "0"
 		);
-		this.labelElement.innerHTML = context.parameters.controlValue.formatted
-			? context.parameters.controlValue.formatted
-			: "0";
+		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+		this.labelElement.innerHTML = context.parameters.controlValue.formatted || "0";
 
 		// appending the HTML elements to the control's HTML container element.
 		this._container.appendChild(this.inputElement);
@@ -110,12 +110,10 @@ export class LinearInputControl implements ComponentFramework.StandardControl<II
 		// storing the latest context from the control.
 		this._value = context.parameters.controlValue.raw!;
 		this._context = context;
-		this.inputElement.value = context.parameters.controlValue.formatted
-			? context.parameters.controlValue.formatted
-			: "";
-		this.labelElement.innerHTML = context.parameters.controlValue.formatted
-			? context.parameters.controlValue.formatted
-			: "";
+		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+		this.inputElement.value = context.parameters.controlValue.formatted || "";
+		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+		this.labelElement.innerHTML = context.parameters.controlValue.formatted || "";
 	}
 
 	/**

--- a/component-framework/ObjectOutputControl/ObjectOutputControl/ControlManifest.Input.xml
+++ b/component-framework/ObjectOutputControl/ObjectOutputControl/ControlManifest.Input.xml
@@ -16,7 +16,7 @@
     <resources>
       <code path="index.ts" order="1"/>
       <platform-library name="React" version="16.14.0" />
-      <platform-library name="Fluent" version="8.29.0" />
+      <platform-library name="Fluent" version="8.121.1" />
     </resources>
   </control>
 </manifest>

--- a/component-framework/ObjectOutputControl/package.json
+++ b/component-framework/ObjectOutputControl/package.json
@@ -13,7 +13,7 @@
 		"refreshTypes": "pcf-scripts refreshTypes"
 	},
 	"dependencies": {
-		"@fluentui/react": "8.29.0",
+		"@fluentui/react": "8.121.1",
 		"react": "^16.14.0",
 		"react-dom": "^16.14.0"
 	},

--- a/component-framework/PowerAppsGridCustomizerControl/PAGridCustomizer/ControlManifest.Input.xml
+++ b/component-framework/PowerAppsGridCustomizerControl/PAGridCustomizer/ControlManifest.Input.xml
@@ -5,7 +5,7 @@
     <resources>
       <code path="index.ts" order="1"/>
       <platform-library name="React" version="16.14.0" />
-      <platform-library name="Fluent" version="8.29.0" />
+      <platform-library name="Fluent" version="8.121.1" />
     </resources>
   </control>
 </manifest>

--- a/component-framework/PowerAppsGridCustomizerControl/package.json
+++ b/component-framework/PowerAppsGridCustomizerControl/package.json
@@ -13,7 +13,7 @@
 		"refreshTypes": "pcf-scripts refreshTypes"
 	},
 	"dependencies": {
-		"@fluentui/react": "8.29.0",
+		"@fluentui/react": "8.121.1",
 		"react": "^16.14.0",
 		"react-dom": "^16.14.0"
 	},

--- a/component-framework/ReactStandardControl/ReactStandardControl/Facepile.tsx
+++ b/component-framework/ReactStandardControl/ReactStandardControl/Facepile.tsx
@@ -33,7 +33,8 @@ export class FacepileBasicExample extends React.Component<IFacepileBasicExampleP
 		super(props);
 
 		this.state = {
-			numberOfFaces: props.numberOfFaces ?? 3,
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			numberOfFaces: props.numberOfFaces || 3,
 			imagesFadeIn: true,
 			personaSize: PersonaSize.size32,
 		};

--- a/component-framework/ReactStandardControl/ReactStandardControl/index.ts
+++ b/component-framework/ReactStandardControl/ReactStandardControl/index.ts
@@ -44,7 +44,8 @@ export class ReactStandardControl implements ComponentFramework.StandardControl<
 		container: HTMLDivElement
 	): void {
 		this.notifyOutputChanged = notifyOutputChanged;
-		this.props.numberOfFaces = context.parameters.numberOfFaces.raw ?? 3;
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			this.props.numberOfFaces = context.parameters.numberOfFaces.raw || 3;
 		this.theContainer = container;
 	}
 
@@ -54,7 +55,8 @@ export class ReactStandardControl implements ComponentFramework.StandardControl<
 	 */
 	public updateView(context: ComponentFramework.Context<IInputs>): void {
 		if (context.updatedProperties.includes("numberOfFaces")) {
-			this.props.numberOfFaces = context.parameters.numberOfFaces.raw ?? 3;
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			this.props.numberOfFaces = context.parameters.numberOfFaces.raw || 3;
 		}
 
 		ReactDOM.render(React.createElement(FacepileBasicExample, this.props), this.theContainer);

--- a/component-framework/resources/GridCustomizerControlTemplate/PAGridCustomizer/ControlManifest.Input.xml
+++ b/component-framework/resources/GridCustomizerControlTemplate/PAGridCustomizer/ControlManifest.Input.xml
@@ -5,7 +5,7 @@
     <resources>
       <code path="index.ts" order="1"/>
       <platform-library name="React" version="16.14.0" />
-      <platform-library name="Fluent" version="8.29.0" />
+      <platform-library name="Fluent" version="8.121.1" />
     </resources>
   </control>
 </manifest>

--- a/component-framework/resources/GridCustomizerControlTemplate/package.json
+++ b/component-framework/resources/GridCustomizerControlTemplate/package.json
@@ -13,7 +13,7 @@
 		"refreshTypes": "pcf-scripts refreshTypes"
 	},
 	"dependencies": {
-		"@fluentui/react": "8.29.0",
+		"@fluentui/react": "8.121.1",
 		"react": "^16.14.0",
 		"react-dom": "^16.14.0"
 	},


### PR DESCRIPTION
Update platform library to use fluent v8 1.121.1 from 8.29.0.
Also fix some linting issues due to prefer-nullish-coalescing