### PR TITLE
PowerShell fix

### DIFF
--- a/dataverse/webapi/PS/Core.ps1
+++ b/dataverse/webapi/PS/Core.ps1
@@ -33,7 +33,7 @@ function Connect {
 
    # Get an access token
    $secureToken = (Get-AzAccessToken `
-      -ResourceUrl $environmentUrl `
+      -ResourceUrl $uri `
       -AsSecureString).Token
 
    # Convert the secure token to a string

--- a/dataverse/webapi/PS/MetadataOperations/MetadataOperationsSample.ps1
+++ b/dataverse/webapi/PS/MetadataOperations/MetadataOperationsSample.ps1
@@ -1326,7 +1326,7 @@ Invoke-DataverseCommands {
    # Get-GlobalOptionSet returns $null if not found
 
    $colorsGlobalOptionSet = Get-GlobalOptionSet `
-      -name $colorsGlobalOptionSetData.Name `
+      -name $colorsGlobalOptionSetData.Name.ToLower() `
       -type 'OptionSet' `
       -query "?`$select=Name,DisplayName,Options"
 


### PR DESCRIPTION
- Fix: `Core.ps1` was using `$environmentUrl`  parameter, which doesn't exist in this scope. 
- (Small) improvement; when reusing the code from the samples, I used caps in the optionset name. Logical name is using small letters only, so referencing the optionset using caps will not find the choice definition. Added `ToLower()` to avoid these issues. I see it's used in many other places, so not doing it in optionset is probably unintentional omission.