### PR TITLE
Exclude the displayName property from the PATCH servicePrincipals call

### DIFF
--- a/powershell/ServerSideSync/ConfigureCrmServerSideSync.ps1
+++ b/powershell/ServerSideSync/ConfigureCrmServerSideSync.ps1
@@ -206,7 +206,7 @@ try
     $servicePrincipalCredentialsForPatch = [System.Collections.Generic.List[object]]::new()
 
     $servicePrincipalCredentialsWorkingCollection | ForEach-Object {
-        $obj = $_ | Select-Object * -ExcludeProperty "key"
+        $obj = $_ | Select-Object * -ExcludeProperty key, displayName
         # Add the modified object to the list
         $servicePrincipalCredentialsForPatch.Add([PSCustomObject]$obj)
     }


### PR DESCRIPTION
Exclude display name to avoid "Update to existing credential with KeyId '<>' is not allowed." error for displayName with special characters