### PR TITLE
Update CreateSubnetInjectionEnterprisePolicy.ps1 to better support single region geos, Update supported list of locations

### DIFF
--- a/powershell/enterprisePolicies/Common/EnterprisePolicyOperations.ps1
+++ b/powershell/enterprisePolicies/Common/EnterprisePolicyOperations.ps1
@@ -99,7 +99,7 @@ function RemoveEnterprisePolicy($policyArmId)
 
 }
 
-function GenerateEnterprisePolicyBody ($policyType, $policyLocation, $policyName, $keyVaultId, $keyName, $keyVersion, $primaryVnetId, $primarySubnetName, $secondaryVnetId = $null, $secondarySubnetName = $null)
+function GenerateEnterprisePolicyBody ($policyType, $policyLocation, $policyName, $keyVaultId, $keyName, $keyVersion, $primaryVnetId, $primarySubnetName, $secondaryVnetId, $secondarySubnetName)
 {   
     if ("cmk" -eq $policyType)
     {
@@ -185,8 +185,3 @@ function GenerateEnterprisePolicyBody ($policyType, $policyLocation, $policyName
 
    return $body
 }
-
-
-
-
-

--- a/powershell/enterprisePolicies/Common/EnterprisePolicyOperations.ps1
+++ b/powershell/enterprisePolicies/Common/EnterprisePolicyOperations.ps1
@@ -99,7 +99,7 @@ function RemoveEnterprisePolicy($policyArmId)
 
 }
 
-function GenerateEnterprisePolicyBody ($policyType, $policyLocation, $policyName, $keyVaultId, $keyName, $keyVersion, $primaryVnetId, $primarySubnetName, $secondaryVnetId, $secondarySubnetName)
+function GenerateEnterprisePolicyBody ($policyType, $policyLocation, $policyName, $keyVaultId, $keyName, $keyVersion, $primaryVnetId, $primarySubnetName, $secondaryVnetId = $null, $secondarySubnetName = $null)
 {   
     if ("cmk" -eq $policyType)
     {
@@ -141,6 +141,25 @@ function GenerateEnterprisePolicyBody ($policyType, $policyLocation, $policyName
     
     elseif ("vnet" -eq $policyType)
     {
+        $virtualNetworks = @(
+            @{
+                "id" = $primaryVnetId
+                "subnet" = @{
+                    "name" = $primarySubnetName
+                }
+            }
+        )
+
+        if ($null -ne $secondaryVnetId)
+        {
+            $virtualNetworks += @{
+                "id" = $secondaryVnetId
+                "subnet" = @{
+                    "name" = $secondarySubnetName
+                }
+            }
+        }
+
         $body = @{
             "`$schema" = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"
             "contentVersion" = "1.0.0.0"
@@ -155,20 +174,7 @@ function GenerateEnterprisePolicyBody ($policyType, $policyLocation, $policyName
                                
                     "properties" = @{
                         "networkInjection" = @{
-                            "virtualNetworks" = @(
-                                @{
-                                    "id" = $primaryVnetId
-                                    "subnet" = @{
-                                        "name" = $primarySubnetName
-                                    }
-                                },
-                                 @{
-                                    "id" = $secondaryVnetId
-                                    "subnet" = @{
-                                        "name" = $secondarySubnetName
-                                    }
-                                }
-                            )
+                            "virtualNetworks" = $virtualNetworks
                         }
                     }
                 }

--- a/powershell/enterprisePolicies/SubnetInjection/CreateSubnetInjectionEnterprisePolicy.ps1
+++ b/powershell/enterprisePolicies/SubnetInjection/CreateSubnetInjectionEnterprisePolicy.ps1
@@ -44,13 +44,13 @@ function CreateSubnetInjectionEnterprisePolicy
 
         [Parameter(
             Mandatory=$true,
-            HelpMessage="Secondary virtual network Id"
+            HelpMessage="Secondary virtual network Id (put N/A if not used)"
         )]
         [string]$secondaryVnetId,
 
         [Parameter(
             Mandatory=$true,
-            HelpMessage="Secondary subnet name"
+            HelpMessage="Secondary subnet name (put N/A if not used)"
         )]
         [string]$secondarySubnetName  
 
@@ -68,20 +68,28 @@ function CreateSubnetInjectionEnterprisePolicy
     Write-Host "Creating Enterprise policy..." -ForegroundColor Green
 
     $primaryVnet = ValidateAndGetVnet -vnetId $primaryVnetId -enterprisePolicylocation $enterprisePolicylocation
-    if ($primaryVnet -eq $null)
+    if ($null -eq $primaryVnet)
     {
        Write-Host "Subnet Injection Enterprise policy not created" -ForegroundColor Red
        return
     }
 
-    $secondaryVnet = ValidateAndGetVnet -vnetId $secondaryVnetId -enterprisePolicylocation $enterprisePolicylocation
-    if ($secondaryVnet -eq $null)
+    $body = $null
+    if ($secondaryVnetId -ieq "N/A")
     {
-       Write-Host "Subnet Injection Enterprise policy not created" -ForegroundColor Red
-       return
-    }
+        Write-Host "Secondary virtual network not provided" -ForegroundColor Green
 
-    $body = GenerateEnterprisePolicyBody -policyType "vnet" -policyLocation $enterprisePolicyLocation -policyName $enterprisePolicyName -primaryVnetId $primaryVnetId -primarySubnetName $primarySubnetName -secondaryVnetId $secondaryVnetId -secondarySubnetName $secondarySubnetName
+        $body = GenerateEnterprisePolicyBody -policyType "vnet" -policyLocation $enterprisePolicyLocation -policyName $enterprisePolicyName -primaryVnetId $primaryVnetId -primarySubnetName $primarySubnetName
+    } else {
+        $secondaryVnet = ValidateAndGetVnet -vnetId $secondaryVnetId -enterprisePolicylocation $enterprisePolicylocation
+        if ($null -eq $secondaryVnet)
+        {
+            Write-Host "Subnet Injection Enterprise policy not created" -ForegroundColor Red
+            return
+        }
+
+        $body = GenerateEnterprisePolicyBody -policyType "vnet" -policyLocation $enterprisePolicyLocation -policyName $enterprisePolicyName -primaryVnetId $primaryVnetId -primarySubnetName $primarySubnetName -secondaryVnetId $secondaryVnetId -secondarySubnetName $secondarySubnetName
+    }
 
     $result = PutEnterprisePolicy $resourceGroup $body
     if ($result -eq $false)

--- a/powershell/enterprisePolicies/SubnetInjection/CreateSubnetInjectionEnterprisePolicy.ps1
+++ b/powershell/enterprisePolicies/SubnetInjection/CreateSubnetInjectionEnterprisePolicy.ps1
@@ -77,7 +77,7 @@ function CreateSubnetInjectionEnterprisePolicy
     $body = $null
     if ($secondaryVnetId -ieq "N/A")
     {
-        Write-Host "Secondary virtual network not provided" -ForegroundColor Green
+        Write-Host "Secondary virtual network not provided" -ForegroundColor Yellow
 
         $body = GenerateEnterprisePolicyBody -policyType "vnet" -policyLocation $enterprisePolicyLocation -policyName $enterprisePolicyName -primaryVnetId $primaryVnetId -primarySubnetName $primarySubnetName
     } else {

--- a/powershell/enterprisePolicies/SubnetInjection/CreateSubnetInjectionEnterprisePolicy.ps1
+++ b/powershell/enterprisePolicies/SubnetInjection/CreateSubnetInjectionEnterprisePolicy.ps1
@@ -44,13 +44,13 @@ function CreateSubnetInjectionEnterprisePolicy
 
         [Parameter(
             Mandatory=$true,
-            HelpMessage="Secondary virtual network Id (put N/A if not used)"
+            HelpMessage="Secondary virtual network Id (put N/A if not used, but vnet is required if geo supports 2+ regions)"
         )]
         [string]$secondaryVnetId,
 
         [Parameter(
             Mandatory=$true,
-            HelpMessage="Secondary subnet name (put N/A if not used)"
+            HelpMessage="Secondary subnet name (put N/A if not used, but subnet is required if geo supports 2+ regions)"
         )]
         [string]$secondarySubnetName  
 

--- a/powershell/enterprisePolicies/SubnetInjection/ValidateVnetLocationForEnterprisePolicy.ps1
+++ b/powershell/enterprisePolicies/SubnetInjection/ValidateVnetLocationForEnterprisePolicy.ps1
@@ -12,14 +12,15 @@ $supportedVnetLocations.Add("europe", "westeurope|northeurope")
 $supportedVnetLocations.Add("germany", "germanynorth|germanywestcentral")
 $supportedVnetLocations.Add("switzerland", "switzerlandnorth|switzerlandwest")
 $supportedVnetLocations.Add("canada", "canadacentral|canadaeast")
-$supportedVnetLocations.Add("brazil", "brazilsouth|southcentralus")
+$supportedVnetLocations.Add("brazil", "brazilsouth")
 $supportedVnetLocations.Add("australia", "australiasoutheast|australiaeast")
 $supportedVnetLocations.Add("asia", "eastasia|southeastasia")
-$supportedVnetLocations.Add("uae", "uaecentral|uaenorth")
+$supportedVnetLocations.Add("uae", "uaenorth")
 $supportedVnetLocations.Add("korea", "koreasouth|koreacentral")
 $supportedVnetLocations.Add("norway", "norwaywest|norwayeast")
 $supportedVnetLocations.Add("singapore", "southeastasia")
 $supportedVnetLocations.Add("sweden", "swedencentral")
+$supportedVnetLocations.Add("italy", "italynorth")
 
 function ValidateAndGetVnet($vnetId, $enterprisePolicylocation) {
 


### PR DESCRIPTION
`CreateSubnetInjectionEnterprisePolicy.ps1` currently mandates a secondary Vnet input even for single region geos. This change allows "n/a" to be supplied and creates the appropriate deployment template to use.

Also updating the list of locations to align with https://learn.microsoft.com/en-us/power-platform/admin/vnet-support-overview#supported-regions  

Example for single region geo:
![image](https://github.com/user-attachments/assets/5b6f88f3-6333-4908-8e0b-03cb385986d9)
