### PR TITLE
Fix incorrect expiry check in ConfigureCrmServerSideSync.ps1

### DIFF
--- a/powershell/ServerSideSync/ConfigureCrmServerSideSync.ps1
+++ b/powershell/ServerSideSync/ConfigureCrmServerSideSync.ps1
@@ -185,7 +185,7 @@ try
     {
         for ($i = 0; $i -lt $servicePrincipalCredentials.Count; $i++)
         {
-            if ($servicePrincipalCredentials[$i].endDateTime -lt $currentDateTime)
+            if ([DateTime]$servicePrincipalCredentials[$i].endDateTime -lt $currentDateTime)
             {
                 Write-Output("Certificate '" + $servicePrincipalCredentials[$i].displayName + "', with thumbprint '" + $servicePrincipalCredentials[$i].customKeyIdentifier + "' has expired on "+ $servicePrincipalCredentials[$i].endDateTime +". Removing the certificate principal from CRM app with id '" + $crmAppId +"'.")
                 $removeID = $servicePrincipalCredentials[$i].keyId


### PR DESCRIPTION
Fixes #797

`endDateTime` on the service principal credential comes back from the Graph API response as a string (e.g. `2024-05-01T00:00:00Z`), but `$currentDateTime` is a `DateTime` object from `Get-Date`. When you compare a string to a DateTime with `-lt`, PowerShell converts the right-hand side to match the type of the left-hand side, so this ends up doing a lexicographic string comparison instead of an actual date comparison. Depending on the string formats involved, that can miss certificates that are genuinely expired, or flag ones that aren't.

The fix casts `endDateTime` to `[DateTime]` before the comparison, same as `$certificateInfo.NotAfter` a few lines above it, which is already a proper DateTime and compares correctly.

Left the `Write-Output` line below it using the raw string value on purpose — that's just for the log message and reads better as the original ISO timestamp.